### PR TITLE
Avoid high memory usage

### DIFF
--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -3987,7 +3987,10 @@ BlobService.prototype._createBlobFromLocalFile = function (container, blob, blob
         }
         callback(createError, createBlob, createResponse);
       };
-      self._uploadBlobFromStream(true, container, blob, blobType, stream, size, options, streamCallback);
+      self._uploadBlobFromStream(true, container, blob, blobType, stream, size, options, function () {
+        stream.finish(); // Avoid a memory surge
+        streamCallback();
+      });
     }
   };
 


### PR DESCRIPTION
When leaving the stream lingering before the subsequent callback, high memory usage has been seen when multiple uploads are happening in parallel. Calling the finish() method to flush to the underlying system alleviates that pressure.